### PR TITLE
Potential fix for code scanning alert no. 85: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/cytheon/juice-shop/security/code-scanning/85](https://github.com/cytheon/juice-shop/security/code-scanning/85)

To fix the issue, we should avoid using the `$where` clause with dynamically interpolated user input. Instead, we can rewrite the query to use a safer, parameterized approach. Specifically, we can use a standard query object to match the `orderId` field directly, which eliminates the need for JavaScript evaluation.

Changes to make:
1. Replace the `$where` clause with a direct query object that matches the `orderId` field.
2. Ensure that the `id` parameter is properly sanitized and validated before use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
