### PR TITLE
Potential fix for code scanning alert no. 81: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge


### PR DESCRIPTION
Potential fix for [https://github.com/cytheon/juice-shop/security/code-scanning/81](https://github.com/cytheon/juice-shop/security/code-scanning/81)

To fix the problem, we need to ensure that the value passed to `isRedirectAllowed` is always a string, and that the function itself does not operate on arrays or other types. The best way to do this is to add a runtime type check in `isRedirectAllowed` to verify that the `url` parameter is a string before using string methods on it. If it is not a string, the function should immediately return `false` (not allowed). This prevents type confusion and ensures that only valid string URLs are checked against the allowlist.

The change should be made in `lib/insecurity.ts`, specifically in the `isRedirectAllowed` function (lines 135-141). No changes are needed in `routes/redirect.ts` because the root cause is in the function that performs the allowlist check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
