### PR TITLE
Potential fix for code scanning alert no. 89: Client-side cross-site scripting

### DIFF
--- a/frontend/src/app/search-result/search-result.component.ts
+++ b/frontend/src/app/search-result/search-result.component.ts
@@ -157,7 +157,7 @@ export class SearchResultComponent implements OnDestroy, AfterViewInit {
         this.io.socket().emit('verifyLocalXssChallenge', queryParam)
       }) // vuln-code-snippet hide-end
       this.dataSource.filter = queryParam.toLowerCase()
-      this.searchValue = this.sanitizer.bypassSecurityTrustHtml(queryParam) // vuln-code-snippet vuln-line localXssChallenge xssBonusChallenge
+      this.searchValue = queryParam
       this.gridDataSource.subscribe((result: any) => {
         if (result.length === 0) {
           this.emptyState = true


### PR DESCRIPTION
Potential fix for [https://github.com/cytheon/juice-shop/security/code-scanning/89](https://github.com/cytheon/juice-shop/security/code-scanning/89)

To fix this vulnerability, user input from the query parameter should not be passed through `bypassSecurityTrustHtml`, as this disables Angular's XSS protection. Instead, the value should be assigned directly to `this.searchValue` and rendered in the template using Angular's default interpolation (`{{ searchValue }}`), which automatically escapes HTML. If the value must be displayed as HTML (e.g., to allow some formatting), it should be sanitized using a robust HTML sanitizer such as [DOMPurify](https://github.com/cure53/DOMPurify) before being passed to `bypassSecurityTrustHtml`. However, for a search query, it is almost always preferable to display it as plain text.

**Steps:**
- In `filterTable()`, assign `queryParam` directly to `this.searchValue` (do not use `bypassSecurityTrustHtml`).
- If the template uses `[innerHTML]="searchValue"`, change it to use `{{ searchValue }}` instead, or ensure that only safe, sanitized HTML is rendered.
- No new imports are needed if only plain text is displayed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
